### PR TITLE
Add batch scripts to start/stop zeppelin on windows

### DIFF
--- a/env.cmd
+++ b/env.cmd
@@ -1,9 +1,17 @@
+@echo off
+
 pushd %~dp0
 set SCRIPT_DIR=%CD%
 popd
 
-set ZEPPELIN_INTP_MEMORY=4
-set ZEPPELIN_ROOT_DIR=%SCRIPT_DIR%\zeppelin
+:: find available RAM
+for /f "skip=1" %%p in ('wmic os get freephysicalmemory') do (
+  set /a memory=%%p/1048576
+  goto :done
+)
+:done
 
+set /a ZEPPELIN_INTP_MEMORY=%memory%/2
+set ZEPPELIN_ROOT_DIR=%SCRIPT_DIR%\zeppelin
 set ZEPPELIN_PORT=8080
 set SPARK_UI_PORT=4080

--- a/env.cmd
+++ b/env.cmd
@@ -1,0 +1,9 @@
+pushd %~dp0
+set SCRIPT_DIR=%CD%
+popd
+
+set ZEPPELIN_INTP_MEMORY=4
+set ZEPPELIN_ROOT_DIR=%SCRIPT_DIR%\zeppelin
+
+set ZEPPELIN_PORT=8080
+set SPARK_UI_PORT=4080

--- a/start-zeppelin.cmd
+++ b/start-zeppelin.cmd
@@ -5,7 +5,7 @@ call env.cmd
 docker-compose up -d
 popd
 
-echo
+echo.
 echo ========== Sqooba Snorkeling Toolset ==========
 echo.
 echo Zeppelin and Spark are starting ... might take some time ...

--- a/start-zeppelin.cmd
+++ b/start-zeppelin.cmd
@@ -1,0 +1,24 @@
+@ECHO OFF
+
+pushd %~dp0
+call env.cmd
+docker-compose up -d
+popd
+
+echo
+echo ========== Sqooba Snorkeling Toolset ==========
+echo.
+echo Zeppelin and Spark are starting ... might take some time ...
+echo.
+echo Zeppelin: http://localhost:%ZEPPELIN_PORT%
+echo Spark:    http://localhost:%SPARK_UI_PORT% -- after you run your first notebook.
+echo.
+echo Upload your data in %ZEPPELIN_ROOT_DIR%\data
+echo Spark logs are stored in %ZEPPELIN_ROOT_DIR%\logs
+echo Your notebooks are stored in %ZEPPELIN_ROOT_DIR%\notebooks
+echo.
+REM echo Run refresh.sh to update js/css/python dependencies
+echo.
+echo ========== Happy Snorkeling ! ==========
+
+@pause

--- a/stop-zeppelin.cmd
+++ b/stop-zeppelin.cmd
@@ -1,0 +1,10 @@
+@ECHO OFF
+
+pushd %~dp0
+call env.cmd
+docker-compose stop
+popd
+
+echo "Zeppelin stopped"
+
+@pause


### PR DESCRIPTION
Add the following Windows scripts:

* `env.cmd` (to set variables used by the other two)
* `start-zeppelin.cmd`
* `stop-zeppelin.cmd`

They have been tested on a Windows 10 Professional Edition and should (in theory) work on any Windows distribution.

_Note_: I chose to create separate files so that users can run scripts by double-clicking on them in the explorer. It spares them the hassle of opening a terminal. 

TODO:

* also provide a `refresh.cmd` script