### PR TITLE
Add batch scripts to start/stop zeppelin on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ data science libraries.
 
 # How to launch it
 
-### On Linux
+### On Linux and macOS
 
 1. `./build-images.sh`
 
@@ -32,7 +32,7 @@ data science libraries.
 
 ### On Windows
 
-Windows scripts are available (`.cdm` extension). You can execute them from the command prompt or the powershell, or simply double-click on them from the explorer (or _right-click > run_).
+Windows scripts are available (`.cmd` extension). You can execute them from the command prompt or the powershell, or simply double-click on them from the explorer (or _right-click > run_).
 
 1. `build-images.cmd`
 
@@ -83,7 +83,7 @@ You can override these values by setting the environment variables, respectively
 
 `zeppelin/bootstrap/js` and `zeppelin/bootstrap/css` lets you deploy JS and CSS libraries inside Zeppelin.
 
-__On Linux__, call `./zeppelin.sh --refresh` to refresh your container without restarting it!
+__On Linux and macOS__, call `./zeppelin.sh --refresh` to refresh your container without restarting it!
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ data science libraries.
 
 # How to launch it
 
+### On Linux
+
 1. `./build-images.sh`
 
    Run __once__ to build the docker image and install the python and javascript dependencies.
@@ -27,6 +29,27 @@ data science libraries.
 
    Stops Zeppelin container
    
+
+### On Windows
+
+Windows scripts are available (`.cdm` extension). You can execute them from the command prompt or the powershell, or simply double-click on them from the explorer (or _right-click > run_).
+
+1. `build-images.cmd`
+
+   Run __once__ to build the docker image and install the python and javascript dependencies.
+   
+2. `start-zeppelin.cmd`
+
+   Starts the Zeppelin container. A command prompt window will appear, press any key to close it.
+   
+   Default port for Zeppelin is 8080, i.e. [http://localhost:8080](http://localhost:8080).
+   Default port for Spark UI is 4040, i.e. [http://localhost:4040](http://localhost:4040), once the first Spark job
+   has been started.
+   
+3. `stop-zeppelin.cmd`
+
+   Stops Zeppelin container. Once again, press any key to close the window.
+
 # Custom configuration
 
 ### Workspace persistence
@@ -47,7 +70,7 @@ to your preferred location before running the `zeppelin.sh --start` script
 ### Zeppelin interpreter memory
 
 By default half of the total available memory will be allocated to the Zeppelin interpreters on start.
-You can override this value by setting the environment variable `ZEPPELIN_INTP_MEMORY` (in Gb, eg: `export ZEPPELIN_INTP_MEMORY=8` for 8 Gb of memory)
+You can override this value by setting the environment variable `ZEPPELIN_INTP_MEMORY` (the value should be `-Xmx<memory>g`, where `<memory>` is the size in GB, eg: `export ZEPPELIN_INTP_MEMORY="-Xmx8g"` for 8 Gb of memory).
 
 ### UI ports
 
@@ -60,7 +83,7 @@ You can override these values by setting the environment variables, respectively
 
 `zeppelin/bootstrap/js` and `zeppelin/bootstrap/css` lets you deploy JS and CSS libraries inside Zeppelin.
 
-Call `./zeppelin.sh --refresh` to refresh your container without restarting it!
+__On Linux__, call `./zeppelin.sh --refresh` to refresh your container without restarting it!
 
 ## Examples
 
@@ -69,8 +92,8 @@ Call `./zeppelin.sh --refresh` to refresh your container without restarting it!
 Say you're missing the python web micro-framework [Flask](https://github.com/pallets/flask). Just add the following line to
 `snorkel/zeppelin/bootstrap/python/requirements.txt`:
 
-	Flask==0.12.2
-	
+    Flask==0.12.2
+    
 And execute `./zeppelin.sh --refresh`. Voilà! Flask is available in your Zeppelin notebook, no restart needed. 
 
 ### JS libraries
@@ -81,15 +104,15 @@ There are two ways to add javascript dependencies to your Zeppelin notebook:
 
 0. By using [unpkg](https://unpkg.com), a _fast, global content delivery network for everything on npm_:
 
-	Add the following script tag to your code in the notebook's snippet: 
-				`<script src="https://unpkg.com/mobx"></script>`
-	This will inject the static (non-minified) source code of the library in your browser.
-	
+    Add the following script tag to your code in the notebook's snippet: 
+                `<script src="https://unpkg.com/mobx"></script>`
+    This will inject the static (non-minified) source code of the library in your browser.
+    
 0. By using the `zeppelin.sh` script:
 
-	* Download the source code of the library from any CDN
-	* Add the js file to the `bootstrap/js` folder
-	* Execute `./zeppelin.sh --refresh`. This will copy the library in the container at a location where Zeppelin can serve it to your browser.
+    * Download the source code of the library from any CDN
+    * Add the js file to the `bootstrap/js` folder
+    * Execute `./zeppelin.sh --refresh`. This will copy the library in the container at a location where Zeppelin can serve it to your browser.
 
 ### Scala/Java dependency
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ to your preferred location before running the `zeppelin.sh --start` script
 ### Zeppelin interpreter memory
 
 By default half of the total available memory will be allocated to the Zeppelin interpreters on start.
-You can override this value by setting the environment variable `ZEPPELIN_INTP_MEMORY` (the value should be `-Xmx<memory>g`, where `<memory>` is the size in GB, eg: `export ZEPPELIN_INTP_MEMORY="-Xmx8g"` for 8 Gb of memory).
+You can override this value by setting the environment variable `ZEPPELIN_MEMORY` (the value should be the size in GB, eg: `export ZEPPELIN_MEMORY=8` for 8 Gb of memory).
 
 ### UI ports
 

--- a/build-images.cmd
+++ b/build-images.cmd
@@ -1,0 +1,16 @@
+pushd %~dp0/zeppelin
+docker build . -t sqooba/zeppelin-starter && (
+  echo "image sqooba/zeppelin-starter built."
+) || (
+  echo "Building image failed."
+  echo "A common problem is that you checked out the directory"
+  echo "with CRLF (i.e. windows) line-ending."
+  echo "Ensure that the scripts in zeppelin/bin have LF line-ending."
+  echo.
+  echo "If the problem persists, open an issue on the github repo."
+)
+popd
+
+
+
+@pause

--- a/build-images.cmd
+++ b/build-images.cmd
@@ -1,4 +1,4 @@
-pushd %~dp0/zeppelin
+pushd %~dp0zeppelin
 docker build . -t sqooba/zeppelin-starter && (
   echo "image sqooba/zeppelin-starter built."
 ) || (

--- a/env.cmd
+++ b/env.cmd
@@ -1,0 +1,18 @@
+@echo off
+
+pushd %~dp0
+set SCRIPT_DIR=%CD%
+popd
+
+:: find available RAM
+set memory=4
+for /f "skip=1" %%p in ('wmic os get freephysicalmemory') do (
+  set /a memory=%%p/1048576/2
+  goto :done
+)
+:done
+
+set ZEPPELIN_INTP_MEMORY=-Xmx%memory%g
+set ZEPPELIN_ROOT_DIR=%SCRIPT_DIR%\zeppelin
+set ZEPPELIN_PORT=8080
+set SPARK_UI_PORT=4080

--- a/env.sh
+++ b/env.sh
@@ -13,8 +13,8 @@ elif [[ $OS == 'Darwin' ]]; then
    CPUS=$(sysctl -n hw.ncpu)
 fi
 
-INTEPRETER_MEMORY=$((MEMORY/2))
-export ZEPPELIN_INTP_MEMORY=${ZEPPELIN_MEMORY:--Xmx${INTEPRETER_MEMORY}g}
+INTERPRETER_MEMORY=$((MEMORY/2))
+export ZEPPELIN_INTP_MEMORY=-Xmx${ZEPPELIN_MEMORY:-$INTERPRETER_MEMORY}g
 
 export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export ZEPPELIN_ROOT_DIR=${ZEPPELIN_ROOT_DIR:-$SCRIPT_DIR/zeppelin}

--- a/env.sh
+++ b/env.sh
@@ -14,7 +14,7 @@ elif [[ $OS == 'Darwin' ]]; then
 fi
 
 INTEPRETER_MEMORY=$((MEMORY/2))
-export ZEPPELIN_INTP_MEMORY=${ZEPPELIN_INTP_MEMORY:--Xmx${INTEPRETER_MEMORY}g}
+export ZEPPELIN_INTP_MEMORY=${ZEPPELIN_MEMORY:--Xmx${INTEPRETER_MEMORY}g}
 
 export SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export ZEPPELIN_ROOT_DIR=${ZEPPELIN_ROOT_DIR:-$SCRIPT_DIR/zeppelin}

--- a/start-zeppelin.cmd
+++ b/start-zeppelin.cmd
@@ -1,4 +1,4 @@
-@ECHO OFF
+@echo off
 
 pushd %~dp0
 call env.cmd

--- a/start-zeppelin.cmd
+++ b/start-zeppelin.cmd
@@ -1,0 +1,24 @@
+@ECHO OFF
+
+pushd %~dp0
+call env.cmd
+docker-compose up -d
+popd
+
+echo.
+echo ========== Sqooba Snorkeling Toolset ==========
+echo.
+echo Zeppelin and Spark are starting ... might take some time ...
+echo.
+echo Zeppelin: http://localhost:%ZEPPELIN_PORT%
+echo Spark:    http://localhost:%SPARK_UI_PORT% -- after you run your first notebook.
+echo.
+echo Upload your data in %ZEPPELIN_ROOT_DIR%\data
+echo Spark logs are stored in %ZEPPELIN_ROOT_DIR%\logs
+echo Your notebooks are stored in %ZEPPELIN_ROOT_DIR%\notebooks
+echo.
+REM echo Run refresh.sh to update js/css/python dependencies
+echo.
+echo ========== Happy Snorkeling ! ==========
+
+@pause

--- a/stop-zeppelin.cmd
+++ b/stop-zeppelin.cmd
@@ -1,4 +1,4 @@
-@ECHO OFF
+@echo off
 
 pushd %~dp0
 call env.cmd

--- a/stop-zeppelin.cmd
+++ b/stop-zeppelin.cmd
@@ -1,0 +1,10 @@
+@ECHO OFF
+
+pushd %~dp0
+call env.cmd
+docker-compose stop
+popd
+
+echo "Zeppelin stopped"
+
+@pause


### PR DESCRIPTION
Add the following Windows scripts (and update README):

* `env.cmd` (to set variables used by the other two)
* `start-zeppelin.cmd`
* `stop-zeppelin.cmd`

They have been tested on a Windows 10 Professional Edition and should (in theory) work on any Windows distribution.

_Note_: I chose to create separate files so that users can run scripts by double-clicking on them in the explorer. It spares them the hassle of opening a terminal.

TODO:

* also provide a `refresh.cmd` script