### PR TITLE
Use version 3.0 of docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.3"
+version: "3.0"
 
 services:
 


### PR DESCRIPTION
Revert to version 3.0 since docker-compose 3.3 is not available on docker for Windows yet

No features from 3.3 are used so it's compatible.